### PR TITLE
Allow compressed initramfs

### DIFF
--- a/fs/common.mk
+++ b/fs/common.mk
@@ -69,6 +69,11 @@ ROOTFS_$(2)_DEPENDENCIES += host-xz
 ROOTFS_$(2)_COMPRESS_EXT = .xz
 ROOTFS_$(2)_COMPRESS_CMD = xz -9 -C crc32 -c
 endif
+ifeq ($$(BR2_TARGET_ROOTFS_$(2)_LZ4),y)
+ROOTFS_$(2)_DEPENDENCIES += host-lz4
+ROOTFS_$(2)_COMPRESS_EXT = .lz4
+ROOTFS_$(2)_COMPRESS_CMD = lz4 -9 -l -c
+endif
 
 $$(BINARIES_DIR)/rootfs.$(1): target-finalize $$(ROOTFS_$(2)_DEPENDENCIES)
 	@$$(call MESSAGE,"Generating root filesystem image rootfs.$(1)")

--- a/fs/cpio/Config.in
+++ b/fs/cpio/Config.in
@@ -46,7 +46,13 @@ config BR2_TARGET_ROOTFS_CPIO_XZ
 	help
 	  Do compress the cpio filesystem with xz.
 
+config BR2_TARGET_ROOTFS_CPIO_LZ4
+	bool "xz"
+	help
+	  Do compress the cpio filesystem with lz4.
+
 endchoice
+
 
 config BR2_TARGET_ROOTFS_CPIO_UIMAGE
 	bool "Create U-Boot image of the root filesystem"

--- a/fs/initramfs/Config.in
+++ b/fs/initramfs/Config.in
@@ -50,7 +50,86 @@ config BR2_INITRAMFS_USE_OTHER
 	  
 endchoice
 
+choice
+	prompt "Compression method"
+	default BR2_TARGET_ROOTFS_INITRAMFS_NONE
+	help
+	  Select compressor for cpio filesystem of the root filesystem.
+	  If you use the cpio archive as an initial RAM filesystem, make
+	  sure the kernel contains the decompression algorithm selected
+	  here.
+
+config BR2_TARGET_ROOTFS_INITRAMFS_NONE
+	bool "no compression"
+	select BR2_TARGET_ROOTFS_CPIO_NONE if BR2_TARGET_ROOTFS_CPIO
+	help
+	  Do not compress the cpio filesystem.
+
+config BR2_TARGET_ROOTFS_INITRAMFS_GZIP
+	bool "gzip"
+	select BR2_TARGET_ROOTFS_CPIO_GZIP if BR2_TARGET_INITRAMFS_USE_ROOTFS
+	help
+	  Do compress the cpio filesystem with gzip.
+
+config BR2_TARGET_ROOTFS_INITRAMFS_BZIP2
+	bool "bzip2"
+	select BR2_TARGET_ROOTFS_CPIO_BZIP2 if BR2_TARGET_INITRAMFS_USE_ROOTFS
+	help
+	  Do compress the cpio filesystem with bzip2.
+
+config BR2_TARGET_ROOTFS_INITRAMFS_LZMA
+	bool "lzma"
+	select BR2_TARGET_ROOTFS_CPIO_LZMA if BR2_TARGET_INITRAMFS_USE_ROOTFS
+	help
+	  Do compress the cpio filesystem with lzma.
+
+config BR2_TARGET_ROOTFS_INITRAMFS_LZO
+	bool "lzo"
+	select BR2_TARGET_ROOTFS_CPIO_LZO if BR2_TARGET_INITRAMFS_USE_ROOTFS
+	help
+	  Do compress the cpio filesystem with lzop.
+
+config BR2_TARGET_ROOTFS_INITRAMFS_XZ
+	bool "xz"
+	select BR2_TARGET_ROOTFS_CPIO_XZ if BR2_TARGET_INITRAMFS_USE_ROOTFS
+	help
+	  Do compress the cpio filesystem with xz.
+
+config BR2_TARGET_ROOTFS_INITRAMFS_LZ4
+	bool "lz4"
+	select BR2_TARGET_ROOTFS_CPIO_LZ4 if BR2_TARGET_INITRAMFS_USE_ROOTFS
+	help
+	  Do compress the cpio filesystem with lz4.
+
+endchoice
+
+if BR2_INITRAMFS_USE_OTHER
+
+endif # BR2_INITRAMFS_USE_OTHER
+
 endif # BR2_TARGET_ROOTFS_INITRAMFS
+
+
+config BR2_CPIO_COMPRESSION
+	string
+	default ""
+	default "gz" if BR2_TARGET_ROOTFS_INITRAMFS_GZIP
+	default "bz2" if BR2_TARGET_ROOTFS_INITRAMFS_BZIP2
+	default "lzma" if BR2_TARGET_ROOTFS_INITRAMFS_LZMA
+	default "lzo" if BR2_TARGET_ROOTFS_INITRAMFS_LZO
+	default "xz" if BR2_TARGET_ROOTFS_INITRAMFS_XZ
+	default "lz4" if BR2_TARGET_ROOTFS_INITRAMFS_LZ4
+
+
+config BR2_CPIO_COMPRESSED_FILE
+	string
+	default "rootfs.cpio"
+	default "rootfs.cpio.gz" if BR2_TARGET_ROOTFS_INITRAMFS_GZIP
+	default "rootfs.cpio.bz2" if BR2_TARGET_ROOTFS_INITRAMFS_BZIP2
+	default "rootfs.cpio.lzma" if BR2_TARGET_ROOTFS_INITRAMFS_LZMA
+	default "rootfs.cpio.lzo" if BR2_TARGET_ROOTFS_INITRAMFS_LZO
+	default "rootfs.cpio.xz" if BR2_TARGET_ROOTFS_INITRAMFS_XZ
+	default "rootfs.cpio.lz4" if BR2_TARGET_ROOTFS_INITRAMFS_LZ4
 
 comment "initramfs needs a Linux kernel to be built"
 	depends on !BR2_LINUX_KERNEL

--- a/fs/initramfs/initramfs.mk
+++ b/fs/initramfs/initramfs.mk
@@ -29,7 +29,7 @@ ifndef $(BR_ROOTFS_CPIO)
 # linux-rebuild-with-iniramfs dependency is 
 # satisfied. A test is also preformed so that the
 # build does not yield unintended results.
-$(BINARIES_DIR)/rootfs.cpio: target-finalize
+$(BINARIES_DIR)/$(BR2_CPIO_COMPRESSED_FILE): target-finalize
 	@$(call MESSAGE,"Using existing rootfs.cpio")
 	@test -f $@ || echo "ERROR: '$(BINARIES_DIR)/rootfs.cpio' was not found"
 

--- a/linux/linux.mk
+++ b/linux/linux.mk
@@ -209,6 +209,9 @@ LINUX_KCONFIG_OPTS = $(LINUX_MAKE_FLAGS)
 # If no package has yet set it, set it from the Kconfig option
 LINUX_NEEDS_MODULES ?= $(BR2_LINUX_NEEDS_MODULES)
 
+LINUX_INITRAMFS_SOURCE=$(BINARIES_DIR)/$(BR2_CPIO_COMPRESSED_FILE)
+export LINUX_INITRAMFS_SOURCE
+
 define LINUX_KCONFIG_FIXUP_CMDS
 	$(if $(LINUX_NEEDS_MODULES),
 		$(call KCONFIG_ENABLE_OPT,CONFIG_MODULES,$(@D)/.config))
@@ -225,8 +228,8 @@ define LINUX_KCONFIG_FIXUP_CMDS
 	# replaced later by the real cpio archive, and the kernel will be
 	# rebuilt using the linux-rebuild-with-initramfs target.
 	$(if $(BR2_TARGET_ROOTFS_INITRAMFS),
-		touch $(BINARIES_DIR)/rootfs.cpio
-		$(call KCONFIG_SET_OPT,CONFIG_INITRAMFS_SOURCE,"$${BR_BINARIES_DIR}/rootfs.cpio",$(@D)/.config)
+		touch $(LINUX_INITRAMFS_SOURCE)
+		$(call KCONFIG_SET_OPT,CONFIG_INITRAMFS_SOURCE,"$${LINUX_INITRAMFS_SOURCE}",$(@D)/.config)
 		$(call KCONFIG_SET_OPT,CONFIG_INITRAMFS_ROOT_UID,0,$(@D)/.config)
 		$(call KCONFIG_SET_OPT,CONFIG_INITRAMFS_ROOT_GID,0,$(@D)/.config))
 	$(if $(BR2_ROOTFS_DEVICE_CREATION_STATIC),,
@@ -442,7 +445,7 @@ $(eval $(kconfig-package))
 
 # Support for rebuilding the kernel after the cpio archive has
 # been generated in $(BINARIES_DIR)/rootfs.cpio.
-$(LINUX_DIR)/.stamp_initramfs_rebuilt: $(LINUX_DIR)/.stamp_target_installed $(LINUX_DIR)/.stamp_images_installed $(BINARIES_DIR)/rootfs.cpio
+$(LINUX_DIR)/.stamp_initramfs_rebuilt: $(LINUX_DIR)/.stamp_target_installed $(LINUX_DIR)/.stamp_images_installed $(LINUX_INITRAMFS_SOURCE)
 	@$(call MESSAGE,"Rebuilding kernel with initramfs")
 	# Build the kernel.
 	$(LINUX_MAKE_ENV) $(MAKE) $(LINUX_MAKE_FLAGS) -C $(@D) $(LINUX_TARGET_NAME)


### PR DESCRIPTION
In the previous patch that enabled separate initramfs image, only the
uncompressed image actually worked. This was probably also true of the origina
Buildroot implementation (unless I'm missing something crucial). This patch
provides a hackish workaround for using separately generated _and compressed_
cpio archive.

This patch also introduces LZ4 compression for filesystems in general so that
compression options are unified across the board.
