### PR TITLE
Add if-up hook to record ip assignment method to wlan interface

### DIFF
--- a/system/skeleton/etc/network/if-up.d/check_ip_assigned
+++ b/system/skeleton/etc/network/if-up.d/check_ip_assigned
@@ -1,0 +1,11 @@
+#!/bin/sh
+IP_ASSIGNMENT_FILE=/var/run/ip_assign_method
+
+assigned_by() {
+  method=$1
+  echo "$method" > $IP_ASSIGNMENT_FILE
+}
+
+if [ "$LOGICAL" = "wlan0" ]; then
+  assigned_by "$METHOD"
+fi


### PR DESCRIPTION
The hook will write the method name (static / dhcp) to a file located at
/var/run/ip_assign_method which will be checked later by a short-living
daemon in case the wireless device runs in station mode
